### PR TITLE
Add TLS option to email component schema

### DIFF
--- a/src/clj/metosin/email.clj
+++ b/src/clj/metosin/email.clj
@@ -69,6 +69,7 @@
             :context s/Any
             :settings {:from s/Str
                        (s/optional-key :smtp) {(s/optional-key :ssl) s/Bool
+                                               (s/optional-key :tls) s/Bool
                                                (s/optional-key :port) s/Int
                                                :host s/Str
                                                :user s/Str


### PR DESCRIPTION
Postal already supports TLS, so this should be the only necessary change as I read the code.