### PR TITLE
Make `boot run-tests` return non-zero on failure

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -82,8 +82,8 @@
 
 (deftask run-tests []
   (comp
-    (alt-test)
-    (test-cljs)))
+    (alt-test :fail true)
+    (test-cljs :exit? true)))
 
 (deftask dev []
   (comp


### PR DESCRIPTION
This way Travis will report actual test failures, not just syntax errors etc.