### PR TITLE
Extend metosin.dates/to-native to native dates.

### DIFF
--- a/src/cljc/metosin/dates.cljc
+++ b/src/cljc/metosin/dates.cljc
@@ -80,7 +80,10 @@
        ; Manually convert to UTC. x.getTimezoneOffset can't be used because it's zero for UtcDateTime.
        (let [d (js/Date. (.getYear x) (.getMonth x) (.getDate x) (.getHours x) (.getMinutes x) (.getSeconds x) (.getMilliseconds x))]
          (.setMinutes d (- (.getMinutes d) (.getTimezoneOffset d)))
-         d)))
+         d))
+     js/Date
+     (to-native [x]
+       x))
    :clj
    (extend-protocol ToNative
      org.joda.time.DateTime
@@ -89,7 +92,10 @@
      org.joda.time.LocalDate
      (to-native [x]
        ; LocalDate toDate creates date in local timezone, that is Helsinki
-       (.toDate (.toDateTimeAtStartOfDay x)))))
+       (.toDate (.toDateTimeAtStartOfDay x)))
+     java.util.Date
+     (to-native [x]
+       x)))
 
 (defprotocol ToDateTime
   (-to-date-time [x] "Convers Date or such to DateTime."))

--- a/test/cljc/metosin/dates_test.cljc
+++ b/test/cljc/metosin/dates_test.cljc
@@ -32,6 +32,12 @@
   (testing "to native"
     (is (= #inst "2015-05-14T09:13" (d/to-native (d/date-time 2015 5 14 9 13))))))
 
+(deftest to-native-test
+  (testing "native date to native is a nop"
+    (let [now #?(:clj (java.util.Date.)
+                 :cljs (js/Date.))]
+      (is (identical? now (d/to-native now))))))
+
 (deftest to-string-test
   (is (= "2015-05-14"
          (d/to-string (d/date 2015 5 14))))


### PR DESCRIPTION
Extend `metosin.dates/to-native` to native date types (java.util.Date and js/Date). The
return value of metosin.dates/to-native for native types is the argument unchanged.

This allows coercing values to native dates, even when no coercion is required.

For example, now I must do this:

```clj
(let [exp (if (instance? Date expiration)
            expiration
            (d/to-native expiration))] 
  (s3/generate-presigned-url module-name key exp))
```

With this change I can do this:

```clj
(s3/generate-presigned-url module-name key (d/to-native expiration))
```
