### PR TITLE
Add IHash implementation for goog.date.Date

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,5 +1,7 @@
 {:lint-as {manifold.deferred/let-flow clojure.core/let
-           clojure.java.jdbc/with-db-connection clojure.core/let}
+           clojure.java.jdbc/with-db-connection clojure.core/let
+           clojure.test.check.clojure-test/defspec clojure.core/def
+           clojure.test.check.properties/for-all clojure.core/let}
  :linters {:if {:level :off}
            :unused-namespace {:exclude [clojure.test cljs.test]}
            :unused-referred-var {:exclude {clojure.test [deftest testing is]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ wanted files from metosin-common to the project repository. Check
 - Deprecate `metosin.edn`, `clojure.tools.reader.edn` can be used instead.
 - Add locale support to `metosin.dates`
 - Handle `nil` in `metosin.dates/format`
+- Add IHash implementation for `goog.date.Date` in `metosin.dates`
 
 ## 0.5.0 (2018-08-31)
 

--- a/src/cljc/metosin/dates.cljc
+++ b/src/cljc/metosin/dates.cljc
@@ -178,7 +178,10 @@
             (identical? (.getTimezoneOffset o) (.getTimezoneOffset other))))
      IComparable
      (-compare [o other]
-       (- (.getTime o) (.getTime other)))))
+       (- (.getTime o) (.getTime other)))
+     IHash
+     (-hash [o]
+       (bit-xor (.getTime o) 0))))
 
 ;;
 ;; Formatter and parser constructors, private.


### PR DESCRIPTION
If you have the implementations for IEquiv and IComparable, you should IHash as well. The implementation mirrors `cljs.core/hash` implementation for `js/Date`:

https://github.com/clojure/clojurescript/blob/599cd05fd271b4ce672e8a6124f0f785b1b3b2d0/src/main/cljs/cljs/core.cljs#L1030-L1031

I have trouble running the tests, but hopefully Travis works...